### PR TITLE
Add F back to Fertigungstechnick

### DIFF
--- a/data/courses.txt
+++ b/data/courses.txt
@@ -193,7 +193,7 @@ Fahrzeugkommunikation_I/2;Fahrzeugkommunikation I/2
 Fahrzeugkommunikation_II;Fahrzeugkommunikation II
 FAQS/Fertigungsinformatik;FAQS/Fertigungsinformatik
 Fertigungsplanung_II_-_Teilefertigung;Fertigungsplanung II - Teilefertigung
-ertigungstechnik;Fertigungstechnik
+Fertigungstechnik;Fertigungstechnik
 Fertigungstechnisches_Praktikum;Fertigungstechnisches Praktikum
 Flugmeteorolgie;Flugmeteorolgie
 Flugplanung;Flugplanung


### PR DESCRIPTION
Add F back to Fertigungstechnik

The F was removed in the last commit. If that was an accident, this PR should add it back in.