### PR TITLE
Adjust the line for modal logic to file schema

### DIFF
--- a/data/courses.txt
+++ b/data/courses.txt
@@ -455,7 +455,7 @@ Mobile_Cartography;Mobile Cartography
 Mobile_Communication_and_Mobile_Computing;Mobile Communication and Mobile Computing
 Mobile_Sensing;Mobile Sensing
 Mobile_Sensing_Lab;Mobile Sensing Lab
-Modal_Logic: Modal Logic
+Modal_Logic;Modal Logic
 Model_Checking;Model-Driven Web Engineering II
 Model-Driven_Web_Engineering_I;Model Checking 
 Model-Driven_Web_Engineering_II;Model-Driven Web Engineering I


### PR DESCRIPTION
Use a semicolon instead of a colon. Could be the reason the line for modal logic is blank in the drop down list.

![grafik](https://github.com/fsr/kpp/assets/80113991/edd88480-edcb-4261-a031-72f8124cbe54)
