### PR TITLE
courses: add machine learning for robotics

### DIFF
--- a/data/courses.txt
+++ b/data/courses.txt
@@ -420,6 +420,7 @@ Logic_Programming_Engineering;Logic Programming Engineering
 Luftverkehrsanlagen,_-betrieb_und_Flugsicherung;Luftverkehrsanlagen, -betrieb und Flugsicherung
 Machine_Learning_1;Machine Learning 1
 Machine_Learning_2:_Structured_Models;Machine Learning 2: Structured Models
+Machine_Learning_for_Robotics;Machine Learning for Robotics
 Machine_Translation_Lab;Machine Translation Lab 
 Makroökonomie_für_Nichtwirtschaftswissenschaftler;Makroökonomie für Nichtwirtschaftswissenschaftler
 Managementprozesse;Managementprozesse


### PR DESCRIPTION
Even though Machine Learning for Robotics does not occur in the courses yet, there is already a folder with protocols:
https://ftp.ifsr.de/komplexpruef/Machine%20Learning%20for%20Robotics/
How were they added? Did I miss it in the list of courses?

I hope this doesn't cause issues like two folders being created